### PR TITLE
add kernel cross build support for faster builds on x86_64-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ use to avoid compiling linux yourself. The cache can be found at
 https://nix-community.cachix.org, and you can follow the instructions there
 to use this cache.
 
+## Cross compiling the kernel
+This can be useful if you cannot or don't want to use the nix-community cache and you do not have a fast aarch64-linux remote builder.
+In this case, set `raspberry-pi-nix.kernel-build-system = "x86_64-linux"` to cross compile the kernel natively on your x86_64-linux machine.
+
 ## Building an sd-card image
 
 Include the provided `sd-image` nixos module this flake provides, then an image

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -26,13 +26,13 @@ let
   boards = [ "bcm2711" "bcm2712" ];
 
   # Helpers for building the `pkgs.rpi-kernels' map.
-  rpi-kernel = { version, board }:
+  rpi-kernel = { version, board, pkgs ? final }:
     let
       kernel = builtins.getAttr version versions;
       version-slug = builtins.replaceStrings [ "v" "_" ] [ "" "." ] version;
     in
     {
-      "${version}"."${board}" = (final.buildLinux {
+      "${version}"."${board}" = (pkgs.buildLinux {
         modDirVersion = version-slug;
         version = version-slug;
         pname = "linux-rpi";
@@ -70,8 +70,20 @@ let
           '';
         });
     };
+
   rpi-kernels = builtins.foldl'
     (b: a: final.lib.recursiveUpdate b (rpi-kernel a))
+    { };
+
+  rip-kernels-cross = buildSystem: builtins.foldl'
+    (b: a: final.lib.recursiveUpdate b (rpi-kernel (
+      a // {
+        pkgs = import final.pkgs.path {
+          system = buildSystem;
+          crossSystem = "aarch64-linux";
+        };
+      }
+    )))
     { };
 in
 {
@@ -114,10 +126,15 @@ in
 
 } // {
   # rpi kernels and firmware are available at
-  # `pkgs.rpi-kernels.<VERSION>.<BOARD>'. 
+  # `pkgs.rpi-kernels.<VERSION>.<BOARD>'.
   #
   # For example: `pkgs.rpi-kernels.v6_6_54.bcm2712'
   rpi-kernels = rpi-kernels (
+    final.lib.cartesianProduct
+      { board = boards; version = (builtins.attrNames versions); }
+  );
+
+  rpi-kernels-cross = buildSystem: rip-kernels-cross buildSystem (
     final.lib.cartesianProduct
       { board = boards; version = (builtins.attrNames versions); }
   );


### PR DESCRIPTION
> This adds the option `raspberry-pi-nix.kernel-build-system`, which can be used to drastically decrease the build times.
> 
> Description of the option:
> 
> The build system to compile the kernel on.
> 
> Only the linux kernel will be cross compiled, while most of the derivations are still pulled from cache.nixos.org.
> 
> Use this if you cannot or don't want to use the nix-community cache and either:
>   - you are building on an x86_64 system using binfmt_misc for aarch64-linux.
>   - or if your x86_64 builder has a better CPU than your aarch64 builder.